### PR TITLE
Feature/Complete functionality to delete documents

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -170,6 +170,8 @@ export async function POST(req: NextRequest) {
       ),
     ).toString('base64');
 
+    // add a chat thing to prisma
+
     return new StreamingTextResponse(stream, {
       headers: {
         'x-message-index': (formattedPreviousMessages.length + 1).toString(),

--- a/app/api/deleteDocument/route.ts
+++ b/app/api/deleteDocument/route.ts
@@ -1,0 +1,96 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/utils/prisma';
+import { getAuth } from '@clerk/nextjs/server';
+
+interface DeleteFileParams {
+  accountId: string;
+  apiKey: string;
+  querystring: {
+    filePath: string;
+  };
+}
+
+async function deleteFile(params: DeleteFileParams) {
+  const baseUrl = 'https://api.bytescale.com';
+  const path = `/v2/accounts/${params.accountId}/files`;
+  const entries = (obj: Record<string, unknown>) =>
+    Object.entries(obj).filter(([, val]) => (val ?? null) !== null) as [
+      string,
+      string,
+    ][];
+  const query = entries(params.querystring ?? {})
+    .flatMap(([k, v]) => (Array.isArray(v) ? v.map((v2) => [k, v2]) : [[k, v]]))
+    .map((kv) => kv.join('='))
+    .join('&');
+  const response = await fetch(
+    `${baseUrl}${path}${query.length > 0 ? '?' : ''}${query}`,
+    {
+      method: 'DELETE',
+      headers: Object.fromEntries(
+        entries({
+          Authorization: `Bearer ${params.apiKey}`,
+        }) as [string, string][],
+      ),
+    },
+  );
+  if (Math.floor(response.status / 100) !== 2) {
+    const result = await response.json();
+    throw new Error(`Bytescale API Error: ${JSON.stringify(result)}`);
+  }
+}
+
+export async function DELETE(request: Request) {
+  const { id, fileUrl } = await request.json();
+
+  const { userId } = getAuth(request as any);
+
+  if (!userId) {
+    return NextResponse.json({ error: 'You must be logged in to delete data' });
+  }
+
+  try {
+    const document = await prisma.document.findFirst({
+      where: {
+        id,
+        userId,
+      },
+    });
+
+    if (!document) {
+      return NextResponse.json({ error: 'Document not found' });
+    }
+
+    const pathWithAccId = fileUrl.replace('https://upcdn.io/', '');
+    const accId = pathWithAccId.split('/')[0];
+    const path = pathWithAccId.replace(`${accId}/raw`, '');
+
+    deleteFile({
+      accountId: accId,
+      apiKey: !!process.env.NEXT_SECRET_BYTESCALE_API_KEY
+        ? process.env.NEXT_SECRET_BYTESCALE_API_KEY
+        : 'no api key found',
+      querystring: {
+        filePath: path,
+      },
+    }).then(
+      () => console.log('Success.'),
+      (error) => {
+        console.error(error);
+        return NextResponse.json({
+          error: 'Could not delete document from cloud',
+        });
+      },
+    );
+
+    await prisma.document.delete({
+      where: {
+        id,
+      },
+    });
+
+    return NextResponse.json({ text: 'Document deleted successfully', id });
+  } catch (error) {
+    console.log('error', error);
+    return NextResponse.json({ error: 'Failed to delete your data' });
+  }
+}

--- a/app/dashboard/dashboard-client.tsx
+++ b/app/dashboard/dashboard-client.tsx
@@ -6,6 +6,14 @@ import { useRouter } from 'next/navigation';
 import DocIcon from '@/components/ui/DocIcon';
 import { formatDistanceToNow } from 'date-fns';
 import { useState } from 'react';
+import TrashIcon from '@/components/ui/Trash';
+
+interface Document {
+  id: string;
+  fileName: string;
+  fileUrl: string;
+  createdAt: Date;
+}
 
 // Configuration for the uploader
 const uploader = Uploader({
@@ -14,10 +22,19 @@ const uploader = Uploader({
     : 'no api key found',
 });
 
-export default function DashboardClient({ docsList }: { docsList: any }) {
+export default function DashboardClient({
+  initialDocsList,
+}: {
+  initialDocsList: Document[];
+}) {
   const router = useRouter();
 
   const [loading, setLoading] = useState(false);
+  const [docsList, setDocsList] = useState(initialDocsList);
+
+  const updateDocsList = (newDocsList: any[]) => {
+    setDocsList(newDocsList);
+  };
 
   const options = {
     maxFileCount: 1,
@@ -70,6 +87,35 @@ export default function DashboardClient({ docsList }: { docsList: any }) {
     router.push(`/document/${data.id}`);
   }
 
+  async function deleteDocument(id: string, fileUrl: string) {
+    try {
+      const res = await fetch('/api/deleteDocument', {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          id,
+          fileUrl,
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error('Failed to delete document');
+      }
+
+      const data = await res.json();
+      if (data.error) {
+        console.log(data.error);
+      } else {
+        console.log('Document deleted successfully');
+        updateDocsList(docsList.filter((doc) => doc.id !== id));
+      }
+    } catch (error) {
+      console.log('Error deleting document', error);
+    }
+  }
+
   return (
     <div className="mx-auto flex flex-col gap-4 container mt-10">
       <h1 className="text-4xl leading-[1.1] tracking-tighter font-medium text-center">
@@ -81,7 +127,7 @@ export default function DashboardClient({ docsList }: { docsList: any }) {
             {docsList.map((doc: any) => (
               <div
                 key={doc.id}
-                className="flex justify-between p-3 hover:bg-gray-100 transition sm:flex-row flex-col sm:gap-0 gap-3"
+                className="flex justify-between p-3 items-center hover:bg-gray-100 transition sm:flex-row flex-col sm:gap-0 gap-3"
               >
                 <button
                   onClick={() => router.push(`/document/${doc.id}`)}
@@ -90,7 +136,12 @@ export default function DashboardClient({ docsList }: { docsList: any }) {
                   <DocIcon />
                   <span>{doc.fileName}</span>
                 </button>
-                <span>{formatDistanceToNow(doc.createdAt)} ago</span>
+                <span className="flex items-center gap-3">
+                  {formatDistanceToNow(doc.createdAt)} ago
+                  <TrashIcon
+                    onClick={() => deleteDocument(doc.id, doc.fileUrl)}
+                  />
+                </span>
               </div>
             ))}
           </div>

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,4 +1,3 @@
-import Footer from '@/components/home/Footer';
 import Header from '@/components/ui/Header';
 
 export default function RootLayout({
@@ -7,12 +6,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen flex flex-col ">
+    <div className="min-h-screen flex flex-col">
       <Header />
-      <div className="flex-grow">{children}</div>
-      <div className="sm:p-7 sm:pb-0">
-        <Footer />
-      </div>
+      {children}
     </div>
   );
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -17,7 +17,7 @@ export default async function Page() {
 
   return (
     <div>
-      <DashboardClient docsList={docsList} />
+      <DashboardClient initialDocsList={docsList} />
     </div>
   );
 }

--- a/components/ui/Trash.tsx
+++ b/components/ui/Trash.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+interface TrashIconProps {
+  onClick: () => void;
+}
+
+const TrashIcon: React.FC<TrashIconProps> = ({ onClick }) => {
+  return (
+    <>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        fill="currentColor"
+        className="bi bi-trash hover:cursor-pointer m-2"
+        viewBox="0 0 16 16"
+        color="red"
+        onClick={onClick}
+      >
+        <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z" />
+        <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z" />
+      </svg>
+    </>
+  );
+};
+
+export default TrashIcon;


### PR DESCRIPTION
Fixes #4 : Unable to delete documents

Hey @jacoblee93 and @Nutlope ! Amazing project.

- This feature successfully handles deletion of documents completely. 
- I have made sure to add functionality such that the document is also deleted from BYTESCALE cloud where the pdf was being stored. 
- It also deletes the record from the Prism-Postgres database.
- The document list also dynamically updates after deletion.
- Everything is pretty much dynamic for scaling

NOTE:
- For this feature to work I had to add an additional .env variable from BYTESCALE. As the current Bytescale key was a public api key it had limited permissions and couldn't delete files. 
- Add the below variable to the .env file:
NEXT_SECRET_BYTESCALE_API_KEY=

This key can be found in: Bytescale Dashboard > Security > API keys > Secret.

I plan to make regular contributions on the project if I am welcome!
Thank you! And hope you find my feature helpful. :smile:
