### PR TITLE
Add MongoDB .env example and schema for prisma

### DIFF
--- a/.env.example-mongodb
+++ b/.env.example-mongodb
@@ -1,0 +1,37 @@
+TOGETHER_AI_API_KEY=
+NEXT_PUBLIC_BYTESCALE_API_KEY=
+
+# The vector store you'd like to use.
+# Can be one of "pinecone" or "mongodb"
+# Defaults to "pinecone"
+NEXT_PUBLIC_VECTORSTORE="mongodb"
+
+# Update these with your pinecone details from your dashboard.
+# Not required if `NEXT_PUBLIC_VECTORSTORE` is set to "mongodb"
+PINECONE_API_KEY=
+PINECONE_INDEX_NAME= # PINECONE_INDEX_NAME is in the indexes tab under "index name" in blue
+
+# Update these with your MongoDB Atlas details from your dashboard.
+# Not required if `NEXT_PUBLIC_VECTORSTORE` is set to "pinecone"
+
+# Make sure you include a database name on the end of your connection string
+MONGODB_ATLAS_URI=mongodb+srv://<name>:<password>!@cluster0.mrfac8r.mongodb.net/pdftochat
+MONGODB_ATLAS_DB_NAME=pdftochat
+MONGODB_ATLAS_COLLECTION_NAME=documents
+MONGODB_ATLAS_INDEX_NAME=vector_index
+
+
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
+CLERK_SECRET_KEY=
+
+NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
+NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
+
+# POSTGRES_URL=
+# POSTGRES_URL_NON_POOLING=
+# POSTGRES_PRISMA_URL=
+
+# Enable tracing via smith.langchain.com
+# LANGCHAIN_TRACING_V2=true
+# LANGCHAIN_API_KEY=
+# LANGCHAIN_SESSION=pdftochat

--- a/prisma/schema.prisma-mongodb
+++ b/prisma/schema.prisma-mongodb
@@ -1,0 +1,17 @@
+generator client {
+    provider = "prisma-client-js"
+}
+
+
+datasource db {
+  provider = "mongodb"
+  url      = env("MONGODB_ATLAS_URI")
+}
+
+model Document {
+    id        String  @id @default(auto()) @map("_id") @db.ObjectId
+    userId    String
+    fileUrl   String
+    fileName  String
+    createdAt DateTime @default(now()) @map(name: "created_at")
+}


### PR DESCRIPTION
Tried to implement pdftochat for MongoDB and ran into a few issues... easily fixed with some minor mods to the .env and prisma/schema files. 